### PR TITLE
[Feat/Auth] JWT를 활용하여 회원가입, 로그인 로직 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
@@ -42,7 +41,6 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/allercheck/backend/BackendApplication.java
+++ b/src/main/java/allercheck/backend/BackendApplication.java
@@ -2,9 +2,10 @@ package allercheck.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.annotation.PropertySource;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @PropertySource("classpath:secure.properties")
 public class BackendApplication {
 

--- a/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
+++ b/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
@@ -1,0 +1,86 @@
+package allercheck.backend.domain.auth.application;
+
+import allercheck.backend.domain.auth.exception.InvalidNameFormatException;
+import allercheck.backend.domain.auth.exception.InvalidPasswordFormatException;
+import allercheck.backend.domain.auth.exception.InvalidUsernameFormatException;
+import allercheck.backend.domain.auth.presentation.dto.MemberResponse;
+import allercheck.backend.domain.auth.presentation.dto.TokenResponse;
+import allercheck.backend.domain.auth.application.dto.MemberSignInRequest;
+import allercheck.backend.domain.auth.application.dto.MemberSignUpRequest;
+import allercheck.backend.domain.auth.exception.PasswordAndCheckedPasswordNotEqualsException;
+import allercheck.backend.domain.auth.exception.UsernameAlreadyExistsException;
+import allercheck.backend.domain.member.domain.Member;
+import allercheck.backend.domain.member.exception.MemberNotFoundException;
+import allercheck.backend.domain.member.repository.MemberRepository;
+import allercheck.backend.global.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final TokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public MemberResponse signUp(final MemberSignUpRequest memberSignUpRequest) {
+        validateSignUpInfo(memberSignUpRequest);
+        validateDuplicatedUsername(memberSignUpRequest);
+        validateCheckedPassword(memberSignUpRequest.getPassword(), memberSignUpRequest.getCheckedPassword());
+        Member member = Member.createMember(memberSignUpRequest.getUsername(),
+                memberSignUpRequest.getPassword(), memberSignUpRequest.getName());
+        memberRepository.save(member);
+        return MemberResponse.toDto(member);
+    }
+
+    public Member extractMember(final String accessToken) {
+        Long memberId = Long.valueOf(tokenProvider.getPayLoad(accessToken));
+        validateMemberId(memberId);
+        return memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
+    private void validateDuplicatedUsername(final MemberSignUpRequest memberSignUpRequest) {
+        if(memberRepository.existsByUsername(memberSignUpRequest.getUsername())) {
+            throw new UsernameAlreadyExistsException();
+        }
+    }
+
+    private void validateCheckedPassword(final String password, final String checkedPassword) {
+        if(!password.equals(checkedPassword)) {
+            throw new PasswordAndCheckedPasswordNotEqualsException();
+        }
+    }
+
+    public void validateMemberId(final Long memberId) {
+        if(!memberRepository.existsById(memberId)) {
+            throw new MemberNotFoundException();
+        }
+    }
+
+    private void validateSignUpInfo(final MemberSignUpRequest memberSignUpRequest) {
+        validateUsernameFormat(memberSignUpRequest.getUsername());
+        validatePasswordFormat(memberSignUpRequest.getPassword());
+        validateNameFormat(memberSignUpRequest.getName());
+    }
+
+    private void validateUsernameFormat(final String username) {
+        if(username == null || !username.matches("^[A-Za-z0-9+_.-]+@(.+)$")) {
+            throw new InvalidUsernameFormatException();
+        }
+    }
+
+    private void validatePasswordFormat(final String password) {
+        if(password == null || !password.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$")) {
+            throw new InvalidPasswordFormatException();
+        }
+    }
+
+    private void validateNameFormat(final String name) {
+        if(name == null || !(name.length() >= 2 && name.length() <= 4)) {
+            throw new InvalidNameFormatException();
+        }
+    }
+}

--- a/src/main/java/allercheck/backend/domain/auth/application/dto/MemberSignUpRequest.java
+++ b/src/main/java/allercheck/backend/domain/auth/application/dto/MemberSignUpRequest.java
@@ -1,0 +1,31 @@
+package allercheck.backend.domain.auth.application.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MemberSignUpRequest {
+
+    @NotBlank
+    @Email(regexp = "^[A-Za-z0-9+_.-]+@(.+)$")
+    private String username;
+
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$")
+    private String password;
+
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$")
+    private String checkedPassword;
+
+    @NotBlank
+    @Size(min = 2, max = 4)
+    private String name;
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/InvalidNameFormatException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/InvalidNameFormatException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class InvalidNameFormatException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/InvalidPasswordFormatException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/InvalidPasswordFormatException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class InvalidPasswordFormatException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/InvalidTokenException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/InvalidTokenException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class InvalidTokenException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/InvalidUsernameFormatException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/InvalidUsernameFormatException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class InvalidUsernameFormatException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/LoginFailureException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/LoginFailureException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class LoginFailureException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/PasswordAndCheckedPasswordNotEqualsException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/PasswordAndCheckedPasswordNotEqualsException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class PasswordAndCheckedPasswordNotEqualsException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/TokenNotFoundException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/TokenNotFoundException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class TokenNotFoundException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/UsernameAlreadyExistsException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/UsernameAlreadyExistsException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class UsernameAlreadyExistsException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/presentation/AuthController.java
+++ b/src/main/java/allercheck/backend/domain/auth/presentation/AuthController.java
@@ -1,0 +1,22 @@
+package allercheck.backend.domain.auth.presentation;
+
+import allercheck.backend.domain.auth.presentation.dto.MemberResponse;
+import allercheck.backend.domain.auth.application.AuthService;
+import allercheck.backend.domain.auth.application.dto.MemberSignUpRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<MemberResponse> signUp(@Valid @RequestBody final MemberSignUpRequest memberSignUpRequest) {
+        return ResponseEntity.ok(authService.signUp(memberSignUpRequest));
+    }
+}

--- a/src/main/java/allercheck/backend/domain/auth/presentation/dto/MemberResponse.java
+++ b/src/main/java/allercheck/backend/domain/auth/presentation/dto/MemberResponse.java
@@ -1,0 +1,20 @@
+package allercheck.backend.domain.auth.presentation.dto;
+
+import allercheck.backend.domain.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MemberResponse {
+
+    private Long id;
+    private String username;
+    private String name;
+
+    public static MemberResponse toDto(Member member) {
+        return new MemberResponse(member.getId(), member.getUsername(), member.getName());
+    }
+}

--- a/src/main/java/allercheck/backend/domain/member/domain/Member.java
+++ b/src/main/java/allercheck/backend/domain/member/domain/Member.java
@@ -1,0 +1,59 @@
+package allercheck.backend.domain.member.domain;
+
+import allercheck.backend.domain.auth.exception.LoginFailureException;
+import allercheck.backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.minidev.json.annotate.JsonIgnore;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    @JsonIgnore
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    public Member(final String username, final String password, final String name) {
+        this.username = username;
+        this.password = password;
+        this.name = name;
+    }
+
+    public static Member createMember(final String username, final String password, final String name) {
+        return new Member(username, password, name);
+    }
+
+    public void changePassword(final String inputPassword) {
+        this.password = inputPassword;
+    }
+
+    public void validateSignInInfo(final String inputUsername, final String inputPassword) {
+        if(!this.username.equals(inputUsername)) {
+            throw new LoginFailureException();
+        }
+
+        if(!this.password.equals(inputPassword)) {
+            throw new LoginFailureException();
+        }
+    }
+
+    public boolean validatePassword(final String inputPassword) {
+        return this.password.equals(inputPassword);
+    }
+}

--- a/src/main/java/allercheck/backend/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/allercheck/backend/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.member.exception;
+
+public class MemberNotFoundException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/allercheck/backend/domain/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package allercheck.backend.domain.member.repository;
+
+import allercheck.backend.domain.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByUsername(final String username);
+
+    boolean existsByUsername(final String username);
+}

--- a/src/main/java/allercheck/backend/global/common/BaseEntity.java
+++ b/src/main/java/allercheck/backend/global/common/BaseEntity.java
@@ -1,0 +1,25 @@
+package allercheck.backend.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/allercheck/backend/global/config/WebConfig.java
+++ b/src/main/java/allercheck/backend/global/config/WebConfig.java
@@ -1,0 +1,55 @@
+package allercheck.backend.global.config;
+
+import allercheck.backend.global.jwt.TokenProvider;
+import allercheck.backend.global.web.filter.CorsFilter;
+import allercheck.backend.global.web.filter.JwtFilter;
+import allercheck.backend.global.web.interceptor.JwtInterceptor;
+import allercheck.backend.global.web.resolver.AuthMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+
+    private final AuthMemberArgumentResolver authmemberArgumentResolver;
+    private final JwtInterceptor jwtInterceptor;
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authmemberArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(jwtInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/api/auth/sign-up", "/api/auth/sign-in");
+    }
+
+    @Bean
+    public FilterRegistrationBean jwtFilter(final TokenProvider tokenProvider) {
+        FilterRegistrationBean<JwtFilter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
+        filterFilterRegistrationBean.setFilter(new JwtFilter(tokenProvider));
+        filterFilterRegistrationBean.setOrder(1);
+        filterFilterRegistrationBean.addUrlPatterns("/*");
+        return filterFilterRegistrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean corsFilter() {
+        FilterRegistrationBean<CorsFilter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new CorsFilter());
+        filterRegistrationBean.setOrder(2);
+        filterRegistrationBean.addUrlPatterns("/*");
+        return filterRegistrationBean;
+    }
+}

--- a/src/main/java/allercheck/backend/global/config/audit/AuditConfig.java
+++ b/src/main/java/allercheck/backend/global/config/audit/AuditConfig.java
@@ -1,0 +1,16 @@
+package allercheck.backend.global.config.audit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
+}

--- a/src/main/java/allercheck/backend/global/config/audit/AuditorAwareImpl.java
+++ b/src/main/java/allercheck/backend/global/config/audit/AuditorAwareImpl.java
@@ -1,0 +1,17 @@
+package allercheck.backend.global.config.audit;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        return Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(e -> e.getAuthentication())
+                .map(Authentication::getName);
+    }
+}

--- a/src/main/java/allercheck/backend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/allercheck/backend/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,67 @@
+package allercheck.backend.global.error;
+
+import allercheck.backend.domain.auth.exception.*;
+import allercheck.backend.domain.member.exception.MemberNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<?> invalidTokenException() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body("유효하지 않은 토큰입니다");
+    }
+
+    @ExceptionHandler(LoginFailureException.class)
+    public ResponseEntity<?> loginFailureException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("id, pw를 다시 확인해주세요.");
+    }
+
+
+    @ExceptionHandler(PasswordAndCheckedPasswordNotEqualsException.class)
+    public ResponseEntity<?> passwordAndCheckedPasswordNotEqualsException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("확인용 비밀번호가 일치하지 않습니다.");
+    }
+
+    @ExceptionHandler(InvalidUsernameFormatException.class)
+    public ResponseEntity<?> invalidUsernameFormatException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("email 형식에 맞춰 입력해주세요.");
+    }
+
+    @ExceptionHandler(InvalidPasswordFormatException.class)
+    public ResponseEntity<?> invalidPasswordFormatException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("특수문자, 알파벳, 숫자를 포함하여 8자 이상 입력해주세요.");
+    }
+
+    @ExceptionHandler(InvalidNameFormatException.class)
+    public ResponseEntity<?> invalidNameFormatException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("이름의 형식이 올바르지 않습니다.");
+    }
+
+    @ExceptionHandler(TokenNotFoundException.class)
+    public ResponseEntity<?> tokenNotFoundException() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("Access Token이 존재하지 않습니다");
+    }
+
+    @ExceptionHandler(UsernameAlreadyExistsException.class)
+    public ResponseEntity<?> usernameAlreadyExistsException() {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body("이미 회원가입된 email입니다.");
+    }
+
+    @ExceptionHandler(MemberNotFoundException.class)
+    public ResponseEntity<?> memberNotFoundException() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("해당 회원을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/allercheck/backend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/allercheck/backend/global/error/GlobalExceptionHandler.java
@@ -19,7 +19,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(LoginFailureException.class)
     public ResponseEntity<?> loginFailureException() {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body("id, pw를 다시 확인해주세요.");
+                .body("email, password를 다시 확인해주세요.");
     }
 
 

--- a/src/main/java/allercheck/backend/global/jwt/AuthorizationExtractor.java
+++ b/src/main/java/allercheck/backend/global/jwt/AuthorizationExtractor.java
@@ -1,0 +1,25 @@
+package allercheck.backend.global.jwt;
+
+import allercheck.backend.domain.auth.exception.InvalidTokenException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class AuthorizationExtractor {
+
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    public static String extract(final HttpServletRequest request) {
+        String authenticationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        validateToken(authenticationHeader);
+        return authenticationHeader.split(" ")[1].trim();
+    }
+
+    private static void validateToken(final String authenticationHeader) {
+        if(!StringUtils.hasText(authenticationHeader) || !authenticationHeader.startsWith(BEARER_PREFIX)) {
+            throw new InvalidTokenException();
+        }
+    }
+}

--- a/src/main/java/allercheck/backend/global/jwt/TokenProvider.java
+++ b/src/main/java/allercheck/backend/global/jwt/TokenProvider.java
@@ -1,0 +1,61 @@
+package allercheck.backend.global.jwt;
+
+import allercheck.backend.domain.auth.exception.InvalidTokenException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+@PropertySource("classpath:secure.properties")
+public class TokenProvider {
+
+    private Key key;
+    private long validityTime;
+
+    public TokenProvider(@Value("${jwt.secret-key}") String secretKey,
+                         @Value("${jwt.token.expire-length}") long validityTime) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.validityTime = validityTime;
+    }
+
+    public String createToken(final String payload) {
+        Date now = new Date();
+        Date exp = new Date(now.getTime() + validityTime);
+
+        return Jwts.builder()
+                .setSubject(payload)
+                .setIssuedAt(now)
+                .setExpiration(exp)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getPayLoad(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public void validateToken(final String token) {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder().
+                    setSigningKey(key).
+                    build().
+                    parseClaimsJws(token);
+        } catch(JwtException | IllegalArgumentException e) {
+            throw new InvalidTokenException();
+        }
+    }
+}

--- a/src/main/java/allercheck/backend/global/web/filter/CorsFilter.java
+++ b/src/main/java/allercheck/backend/global/web/filter/CorsFilter.java
@@ -1,0 +1,22 @@
+package allercheck.backend.global.web.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class CorsFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response,
+                                    final FilterChain chain) throws ServletException, IOException {
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
+        response.setHeader("Access-Control-Allow-Methods", "*");
+        response.setHeader("Access-Control-Max-Age", "3600");
+        response.setHeader("Access-Control-Allow-Headers", "*");
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/allercheck/backend/global/web/filter/JwtFilter.java
+++ b/src/main/java/allercheck/backend/global/web/filter/JwtFilter.java
@@ -1,0 +1,58 @@
+package allercheck.backend.global.web.filter;
+
+import allercheck.backend.domain.auth.exception.InvalidTokenException;
+import allercheck.backend.global.jwt.TokenProvider;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.PatternMatchUtils;
+
+import java.io.IOException;
+
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter implements Filter {
+
+    private static final String[] whiteList = { "/", "/api/auth/sign-in", "/api/auth/sign-up", "/css/*"};
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request,
+                         ServletResponse response,
+                         FilterChain chain) throws IOException, ServletException {
+        log.info("call doFilter method >>>");
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String requestUri = httpRequest.getRequestURI();
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        if(!isLoginCheckPath(requestUri)) {
+            chain.doFilter(httpRequest, httpResponse);
+            return;
+        }
+
+        String authorizationHeader = httpRequest.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+            return;
+        }
+
+        String token = authorizationHeader.substring(7);
+
+        try {
+            tokenProvider.validateToken(token);
+            chain.doFilter(httpRequest, httpResponse);
+        } catch (InvalidTokenException e) {
+            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+        }
+    }
+
+    private boolean isLoginCheckPath(final String requestUri) {
+        return !PatternMatchUtils.simpleMatch(whiteList, requestUri);
+    }
+}

--- a/src/main/java/allercheck/backend/global/web/interceptor/JwtInterceptor.java
+++ b/src/main/java/allercheck/backend/global/web/interceptor/JwtInterceptor.java
@@ -1,0 +1,30 @@
+package allercheck.backend.global.web.interceptor;
+
+import allercheck.backend.global.jwt.AuthorizationExtractor;
+import allercheck.backend.global.jwt.TokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtInterceptor implements HandlerInterceptor {
+
+    private final AuthorizationExtractor authorizationExtractor;
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request,
+                             final HttpServletResponse response,
+                             final Object handler) throws Exception {
+        log.info("call preHandle method >> ");
+        String extractedToken = authorizationExtractor.extract(request);
+        String name = tokenProvider.getPayLoad(extractedToken);
+        request.setAttribute("name", name);
+        return true;
+    }
+}

--- a/src/main/java/allercheck/backend/global/web/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/allercheck/backend/global/web/resolver/AuthMemberArgumentResolver.java
@@ -1,0 +1,35 @@
+package allercheck.backend.global.web.resolver;
+
+import allercheck.backend.domain.auth.application.AuthService;
+import allercheck.backend.global.web.resolver.annotation.AuthMember;
+import allercheck.backend.global.jwt.AuthorizationExtractor;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthService authService;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter,
+                                  final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest,
+                                  final WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String accessToken = AuthorizationExtractor.extract(request);
+        return authService.extractMember(accessToken);
+    }
+}

--- a/src/main/java/allercheck/backend/global/web/resolver/annotation/AuthMember.java
+++ b/src/main/java/allercheck/backend/global/web/resolver/annotation/AuthMember.java
@@ -1,0 +1,11 @@
+package allercheck.backend.global.web.resolver.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER) // annotation이 생설될 수 있는 위치 지정(Parameter 선언시)
+@Retention(RetentionPolicy.RUNTIME) // annotation이 언제까지 유효하는지 지정(Complie 이후에도 존재)
+public @interface AuthMember {
+}

--- a/src/main/resources/secure.properties
+++ b/src/main/resources/secure.properties
@@ -1,2 +1,2 @@
 jwt.secret-key = c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK
-
+jwt.token.expire-length = 36000000


### PR DESCRIPTION
1. 기존 JWT + Spring Security 방식에서는 Controller에서 Member 객체를 가져와야 했는데, 이러한 중복 로직을 제거하기 위한 Resolver 구현 
2. Filter, Interceptor를 구현하여 인증 관련 공통로직을 구분  
3. Filter는 ServletContainer(스프링 영역 밖)에서 동작, Interceptor는 Spring Context(스프링 영역 안)에서 동작하기에 이들을 구분하여 설계
