### PR TITLE
[Refactor/Auth] 회원가입, 로그인 로직 관련 리팩토링 및 Service, Controller, Repository 단위 테스트 추가

### DIFF
--- a/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
+++ b/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
@@ -17,8 +17,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+
 @RequiredArgsConstructor
+@Service
 public class AuthService {
 
     private final TokenProvider tokenProvider;

--- a/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
+++ b/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
@@ -4,7 +4,7 @@ import allercheck.backend.domain.auth.application.dto.MemberSignInRequest;
 import allercheck.backend.domain.auth.application.dto.MemberSignUpRequest;
 import allercheck.backend.domain.auth.exception.PasswordAndCheckedPasswordNotEqualsException;
 import allercheck.backend.domain.auth.exception.UsernameAlreadyExistsException;
-import allercheck.backend.domain.member.domain.Member;
+import allercheck.backend.domain.member.entity.Member;
 import allercheck.backend.domain.member.exception.MemberNotFoundException;
 import allercheck.backend.domain.member.repository.MemberRepository;
 import allercheck.backend.global.jwt.TokenProvider;

--- a/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
+++ b/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
@@ -27,7 +27,6 @@ public class AuthService {
 
     @Transactional
     public MemberResponse signUp(final MemberSignUpRequest memberSignUpRequest) {
-        validateSignUpInfo(memberSignUpRequest);
         validateDuplicatedUsername(memberSignUpRequest);
         validateCheckedPassword(memberSignUpRequest.getPassword(), memberSignUpRequest.getCheckedPassword());
         Member member = Member.createMember(memberSignUpRequest.getUsername(),
@@ -67,30 +66,6 @@ public class AuthService {
     public void validateMemberId(final Long memberId) {
         if(!memberRepository.existsById(memberId)) {
             throw new MemberNotFoundException();
-        }
-    }
-
-    private void validateSignUpInfo(final MemberSignUpRequest memberSignUpRequest) {
-        validateUsernameFormat(memberSignUpRequest.getUsername());
-        validatePasswordFormat(memberSignUpRequest.getPassword());
-        validateNameFormat(memberSignUpRequest.getName());
-    }
-
-    private void validateUsernameFormat(final String username) {
-        if(username == null || !username.matches("^[A-Za-z0-9+_.-]+@(.+)$")) {
-            throw new InvalidUsernameFormatException();
-        }
-    }
-
-    private void validatePasswordFormat(final String password) {
-        if(password == null || !password.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$")) {
-            throw new InvalidPasswordFormatException();
-        }
-    }
-
-    private void validateNameFormat(final String name) {
-        if(name == null || !(name.length() >= 2 && name.length() <= 4)) {
-            throw new InvalidNameFormatException();
         }
     }
 }

--- a/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
+++ b/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
@@ -1,7 +1,5 @@
 package allercheck.backend.domain.auth.application;
 
-import allercheck.backend.domain.auth.presentation.dto.MemberResponse;
-import allercheck.backend.domain.auth.presentation.dto.TokenResponse;
 import allercheck.backend.domain.auth.application.dto.MemberSignInRequest;
 import allercheck.backend.domain.auth.application.dto.MemberSignUpRequest;
 import allercheck.backend.domain.auth.exception.PasswordAndCheckedPasswordNotEqualsException;
@@ -23,22 +21,21 @@ public class AuthService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public MemberResponse signUp(final MemberSignUpRequest memberSignUpRequest) {
+    public Member signUp(final MemberSignUpRequest memberSignUpRequest) {
         validateDuplicatedUsername(memberSignUpRequest);
         validateCheckedPassword(memberSignUpRequest.getPassword(), memberSignUpRequest.getCheckedPassword());
         Member member = Member.createMember(memberSignUpRequest.getUsername(),
                 memberSignUpRequest.getPassword(), memberSignUpRequest.getName());
-        memberRepository.save(member);
-        return MemberResponse.toDto(member);
+        return memberRepository.save(member);
     }
 
     @Transactional
-    public TokenResponse signIn(final MemberSignInRequest memberSignInRequest) {
+    public String signIn(final MemberSignInRequest memberSignInRequest) {
         Member member = memberRepository.findByUsername(memberSignInRequest.getUsername())
                 .orElseThrow(MemberNotFoundException::new);
         member.validateSignInInfo(memberSignInRequest.getUsername(), memberSignInRequest.getPassword());
         member.validatePassword(member.getPassword());
-        return new TokenResponse(tokenProvider.createToken(String.valueOf(member.getId())));
+        return tokenProvider.createToken(String.valueOf(member.getId()));
     }
 
     public Member extractMember(final String accessToken) {

--- a/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
+++ b/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
@@ -31,11 +31,16 @@ public class AuthService {
 
     @Transactional
     public String signIn(final MemberSignInRequest memberSignInRequest) {
-        Member member = memberRepository.findByUsername(memberSignInRequest.getUsername())
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = findMember(memberSignInRequest);
         member.validateSignInInfo(memberSignInRequest.getUsername(), memberSignInRequest.getPassword());
         member.validatePassword(member.getPassword());
         return tokenProvider.createToken(String.valueOf(member.getId()));
+    }
+
+    private Member findMember(MemberSignInRequest memberSignInRequest) {
+        Member member = memberRepository.findByUsername(memberSignInRequest.getUsername())
+                .orElseThrow(MemberNotFoundException::new);
+        return member;
     }
 
     public Member extractMember(final String accessToken) {

--- a/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
+++ b/src/main/java/allercheck/backend/domain/auth/application/AuthService.java
@@ -1,8 +1,5 @@
 package allercheck.backend.domain.auth.application;
 
-import allercheck.backend.domain.auth.exception.InvalidNameFormatException;
-import allercheck.backend.domain.auth.exception.InvalidPasswordFormatException;
-import allercheck.backend.domain.auth.exception.InvalidUsernameFormatException;
 import allercheck.backend.domain.auth.presentation.dto.MemberResponse;
 import allercheck.backend.domain.auth.presentation.dto.TokenResponse;
 import allercheck.backend.domain.auth.application.dto.MemberSignInRequest;
@@ -13,10 +10,10 @@ import allercheck.backend.domain.member.domain.Member;
 import allercheck.backend.domain.member.exception.MemberNotFoundException;
 import allercheck.backend.domain.member.repository.MemberRepository;
 import allercheck.backend.global.jwt.TokenProvider;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/allercheck/backend/domain/auth/application/dto/MemberSignInRequest.java
+++ b/src/main/java/allercheck/backend/domain/auth/application/dto/MemberSignInRequest.java
@@ -5,9 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
 public class MemberSignInRequest {
 
     @NotBlank

--- a/src/main/java/allercheck/backend/domain/auth/application/dto/MemberSignUpRequest.java
+++ b/src/main/java/allercheck/backend/domain/auth/application/dto/MemberSignUpRequest.java
@@ -8,9 +8,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
 public class MemberSignUpRequest {
 
     @NotBlank

--- a/src/main/java/allercheck/backend/domain/auth/exception/NewPasswordNotEqualsException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/NewPasswordNotEqualsException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class NewPasswordNotEqualsException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/PasswordNotEqualsException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/PasswordNotEqualsException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class PasswordNotEqualsException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/PresentPasswordNotEqualsException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/PresentPasswordNotEqualsException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class PresentPasswordNotEqualsException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/auth/exception/UsernameNotEqualsException.java
+++ b/src/main/java/allercheck/backend/domain/auth/exception/UsernameNotEqualsException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.auth.exception;
+
+public class UsernameNotEqualsException extends RuntimeException{
+}

--- a/src/main/java/allercheck/backend/domain/auth/presentation/AuthController.java
+++ b/src/main/java/allercheck/backend/domain/auth/presentation/AuthController.java
@@ -10,9 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/auth")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/allercheck/backend/domain/auth/presentation/AuthController.java
+++ b/src/main/java/allercheck/backend/domain/auth/presentation/AuthController.java
@@ -5,8 +5,10 @@ import allercheck.backend.domain.auth.presentation.dto.MemberResponse;
 import allercheck.backend.domain.auth.application.AuthService;
 import allercheck.backend.domain.auth.application.dto.MemberSignUpRequest;
 import allercheck.backend.domain.auth.presentation.dto.TokenResponse;
+import allercheck.backend.domain.member.domain.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,11 +21,15 @@ public class AuthController {
 
     @PostMapping("/sign-up")
     public ResponseEntity<MemberResponse> signUp(@Valid @RequestBody final MemberSignUpRequest memberSignUpRequest) {
-        return ResponseEntity.ok(authService.signUp(memberSignUpRequest));
+        Member member = authService.signUp(memberSignUpRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(MemberResponse.toDto(member));
     }
 
     @PostMapping("/sign-in")
     public ResponseEntity<TokenResponse> signIn(@Valid @RequestBody final MemberSignInRequest memberSignInRequest) {
-        return ResponseEntity.ok(authService.signIn(memberSignInRequest));
+        String accessToken = authService.signIn(memberSignInRequest);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new TokenResponse(accessToken));
     }
 }

--- a/src/main/java/allercheck/backend/domain/auth/presentation/AuthController.java
+++ b/src/main/java/allercheck/backend/domain/auth/presentation/AuthController.java
@@ -5,7 +5,7 @@ import allercheck.backend.domain.auth.presentation.dto.MemberResponse;
 import allercheck.backend.domain.auth.application.AuthService;
 import allercheck.backend.domain.auth.application.dto.MemberSignUpRequest;
 import allercheck.backend.domain.auth.presentation.dto.TokenResponse;
-import allercheck.backend.domain.member.domain.Member;
+import allercheck.backend.domain.member.entity.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/allercheck/backend/domain/auth/presentation/dto/MemberResponse.java
+++ b/src/main/java/allercheck/backend/domain/auth/presentation/dto/MemberResponse.java
@@ -1,6 +1,6 @@
 package allercheck.backend.domain.auth.presentation.dto;
 
-import allercheck.backend.domain.member.domain.Member;
+import allercheck.backend.domain.member.entity.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/allercheck/backend/domain/auth/presentation/dto/MemberResponse.java
+++ b/src/main/java/allercheck/backend/domain/auth/presentation/dto/MemberResponse.java
@@ -5,9 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
 public class MemberResponse {
 
     private Long id;

--- a/src/main/java/allercheck/backend/domain/auth/presentation/dto/TokenResponse.java
+++ b/src/main/java/allercheck/backend/domain/auth/presentation/dto/TokenResponse.java
@@ -4,9 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
 public class TokenResponse {
 
     private String accessToken;

--- a/src/main/java/allercheck/backend/domain/member/domain/Member.java
+++ b/src/main/java/allercheck/backend/domain/member/domain/Member.java
@@ -1,5 +1,8 @@
 package allercheck.backend.domain.member.domain;
 
+import allercheck.backend.domain.auth.exception.InvalidNameFormatException;
+import allercheck.backend.domain.auth.exception.InvalidPasswordFormatException;
+import allercheck.backend.domain.auth.exception.InvalidUsernameFormatException;
 import allercheck.backend.domain.auth.exception.LoginFailureException;
 import allercheck.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -30,6 +33,7 @@ public class Member extends BaseEntity {
     private String name;
 
     private Member(final String username, final String password, final String name) {
+        validateMember(username, password, name);
         this.username = username;
         this.password = password;
         this.name = name;
@@ -55,5 +59,27 @@ public class Member extends BaseEntity {
 
     public boolean validatePassword(final String inputPassword) {
         return this.password.equals(inputPassword);
+    }
+
+    public static void validateMember(final String username, final String password, final String name) {
+        validateUsernameFormat(username);
+    }
+
+    private static void validateUsernameFormat(final String username) {
+        if(username == null || !username.matches("^[A-Za-z0-9+_.-]+@(.+)$")) {
+            throw new InvalidUsernameFormatException();
+        }
+    }
+
+    private static void validatePasswordFormat(final String password) {
+        if(password == null || !password.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$")) {
+            throw new InvalidPasswordFormatException();
+        }
+    }
+
+    private static void validateNameFormat(final String name) {
+        if (name == null || !(name.length() >= 2 && name.length() <= 4)) {
+            throw new InvalidNameFormatException();
+        }
     }
 }

--- a/src/main/java/allercheck/backend/domain/member/domain/Member.java
+++ b/src/main/java/allercheck/backend/domain/member/domain/Member.java
@@ -12,10 +12,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.minidev.json.annotate.JsonIgnore;
 
-@Entity
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
+@Entity
 public class Member extends BaseEntity {
 
     @Id
@@ -63,6 +63,8 @@ public class Member extends BaseEntity {
 
     public static void validateMember(final String username, final String password, final String name) {
         validateUsernameFormat(username);
+        validatePasswordFormat(password);
+        validateNameFormat(name);
     }
 
     private static void validateUsernameFormat(final String username) {

--- a/src/main/java/allercheck/backend/domain/member/domain/Member.java
+++ b/src/main/java/allercheck/backend/domain/member/domain/Member.java
@@ -29,7 +29,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    public Member(final String username, final String password, final String name) {
+    private Member(final String username, final String password, final String name) {
         this.username = username;
         this.password = password;
         this.name = name;

--- a/src/main/java/allercheck/backend/domain/member/entity/Member.java
+++ b/src/main/java/allercheck/backend/domain/member/entity/Member.java
@@ -1,4 +1,4 @@
-package allercheck.backend.domain.member.domain;
+package allercheck.backend.domain.member.entity;
 
 import allercheck.backend.domain.auth.exception.InvalidNameFormatException;
 import allercheck.backend.domain.auth.exception.InvalidPasswordFormatException;

--- a/src/main/java/allercheck/backend/domain/member/entity/Member.java
+++ b/src/main/java/allercheck/backend/domain/member/entity/Member.java
@@ -4,6 +4,8 @@ import allercheck.backend.domain.auth.exception.InvalidNameFormatException;
 import allercheck.backend.domain.auth.exception.InvalidPasswordFormatException;
 import allercheck.backend.domain.auth.exception.InvalidUsernameFormatException;
 import allercheck.backend.domain.auth.exception.LoginFailureException;
+import allercheck.backend.domain.auth.exception.PasswordNotEqualsException;
+import allercheck.backend.domain.auth.exception.PresentPasswordNotEqualsException;
 import allercheck.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -49,11 +51,11 @@ public class Member extends BaseEntity {
 
     public void validateSignInInfo(final String inputUsername, final String inputPassword) {
         if(!this.username.equals(inputUsername)) {
-            throw new LoginFailureException();
+            throw new PresentPasswordNotEqualsException();
         }
 
         if(!this.password.equals(inputPassword)) {
-            throw new LoginFailureException();
+            throw new PasswordNotEqualsException();
         }
     }
 

--- a/src/main/java/allercheck/backend/domain/member/entity/Member.java
+++ b/src/main/java/allercheck/backend/domain/member/entity/Member.java
@@ -3,9 +3,7 @@ package allercheck.backend.domain.member.entity;
 import allercheck.backend.domain.auth.exception.InvalidNameFormatException;
 import allercheck.backend.domain.auth.exception.InvalidPasswordFormatException;
 import allercheck.backend.domain.auth.exception.InvalidUsernameFormatException;
-import allercheck.backend.domain.auth.exception.LoginFailureException;
 import allercheck.backend.domain.auth.exception.PasswordNotEqualsException;
-import allercheck.backend.domain.auth.exception.PresentPasswordNotEqualsException;
 import allercheck.backend.domain.auth.exception.UsernameNotEqualsException;
 import allercheck.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -14,7 +12,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.minidev.json.annotate.JsonIgnore;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/allercheck/backend/domain/member/entity/Member.java
+++ b/src/main/java/allercheck/backend/domain/member/entity/Member.java
@@ -6,6 +6,7 @@ import allercheck.backend.domain.auth.exception.InvalidUsernameFormatException;
 import allercheck.backend.domain.auth.exception.LoginFailureException;
 import allercheck.backend.domain.auth.exception.PasswordNotEqualsException;
 import allercheck.backend.domain.auth.exception.PresentPasswordNotEqualsException;
+import allercheck.backend.domain.auth.exception.UsernameNotEqualsException;
 import allercheck.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -13,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.minidev.json.annotate.JsonIgnore;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 @Getter
 @AllArgsConstructor
@@ -51,7 +53,7 @@ public class Member extends BaseEntity {
 
     public void validateSignInInfo(final String inputUsername, final String inputPassword) {
         if(!this.username.equals(inputUsername)) {
-            throw new PresentPasswordNotEqualsException();
+            throw new UsernameNotEqualsException();
         }
 
         if(!this.password.equals(inputPassword)) {

--- a/src/main/java/allercheck/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/allercheck/backend/domain/member/repository/MemberRepository.java
@@ -1,6 +1,6 @@
 package allercheck.backend.domain.member.repository;
 
-import allercheck.backend.domain.member.domain.Member;
+import allercheck.backend.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/allercheck/backend/global/config/WebConfig.java
+++ b/src/main/java/allercheck/backend/global/config/WebConfig.java
@@ -15,8 +15,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
-@Configuration
 @RequiredArgsConstructor
+@Configuration
 public class WebConfig implements WebMvcConfigurer {
 
 

--- a/src/main/java/allercheck/backend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/allercheck/backend/global/error/GlobalExceptionHandler.java
@@ -64,4 +64,28 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body("해당 회원을 찾을 수 없습니다.");
     }
+
+    @ExceptionHandler(UsernameNotEqualsException.class)
+    public ResponseEntity<?> usernameNotEqualsException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("email 정보가 일치하지 않습니다.");
+    }
+
+    @ExceptionHandler(PasswordNotEqualsException.class)
+    public ResponseEntity<?> passwordNotEqualsException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("올바른 password를 입력해 주세요.");
+    }
+
+    @ExceptionHandler(PresentPasswordNotEqualsException.class)
+    public ResponseEntity<?> presentPasswordNotEqualsException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("현재 password를 올바르게 입력해주세요.");
+    }
+
+    @ExceptionHandler(NewPasswordNotEqualsException.class)
+    public ResponseEntity<?> newPasswordNotEqualsException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("새로운 password를 올바르게 입력해주세요.");
+    }
 }

--- a/src/main/java/allercheck/backend/global/web/resolver/annotation/AuthMember.java
+++ b/src/main/java/allercheck/backend/global/web/resolver/annotation/AuthMember.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.PARAMETER) // annotation이 생설될 수 있는 위치 지정(Parameter 선언시)
-@Retention(RetentionPolicy.RUNTIME) // annotation이 언제까지 유효하는지 지정(Complie 이후에도 존재)
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface AuthMember {
 }

--- a/src/test/java/allercheck/backend/auth/application/AuthServiceUnitTest.java
+++ b/src/test/java/allercheck/backend/auth/application/AuthServiceUnitTest.java
@@ -1,0 +1,168 @@
+package allercheck.backend.auth.application;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import allercheck.backend.domain.auth.application.AuthService;
+import allercheck.backend.domain.auth.application.dto.MemberSignInRequest;
+import allercheck.backend.domain.auth.application.dto.MemberSignUpRequest;
+import allercheck.backend.domain.auth.exception.InvalidNameFormatException;
+import allercheck.backend.domain.auth.exception.InvalidPasswordFormatException;
+import allercheck.backend.domain.auth.exception.InvalidUsernameFormatException;
+import allercheck.backend.domain.auth.exception.PasswordAndCheckedPasswordNotEqualsException;
+import allercheck.backend.domain.auth.exception.PasswordNotEqualsException;
+import allercheck.backend.domain.auth.exception.UsernameAlreadyExistsException;
+import allercheck.backend.domain.auth.exception.UsernameNotEqualsException;
+import allercheck.backend.domain.member.entity.Member;
+import allercheck.backend.domain.member.repository.MemberRepository;
+import allercheck.backend.global.jwt.TokenProvider;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class AuthServiceUnitTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Test
+    void 회원가입을_한다() {
+        // Given
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kimsb7218@naver.com", "daily1313!"
+                ,"daily1313!", "김승범");
+        Member member = Member.createMember(memberSignUpRequest.getUsername(),
+                memberSignUpRequest.getPassword(), memberSignUpRequest.getName());
+        given(memberRepository.existsByUsername(anyString())).willReturn(false);
+        given(memberRepository.save(any(Member.class))).willReturn(member);
+
+        // When
+        Member createdMember = authService.signUp(memberSignUpRequest);
+
+        // Then
+        assertThat(createdMember.getUsername()).isEqualTo(memberSignUpRequest.getUsername());
+        assertThat(createdMember.getName()).isEqualTo(memberSignUpRequest.getName());
+    }
+
+    @Test
+    void 로그인을_한다() {
+        // Given
+        String token = "token";
+        Member member = Member.createMember("kimsb7218@naver.com", "daily1313!", "김승범");
+        MemberSignInRequest memberSignInRequest = new MemberSignInRequest(member.getUsername(), member.getPassword());
+        given(memberRepository.findByUsername(anyString())).willReturn(Optional.of(member));
+        given(tokenProvider.createToken(anyString())).willReturn(token);
+
+        // When
+        String accessToken = authService.signIn(memberSignInRequest);
+
+        // Then
+        assertThat(accessToken).isEqualTo(token);
+    }
+
+    @Test
+    void 이메일_값이_공백_이면_예외가_발생_한다() {
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("", "daily1313!", "daily1313!", "김승범");
+
+        assertThatThrownBy(() -> authService.signUp(memberSignUpRequest))
+                .isInstanceOf(InvalidUsernameFormatException.class);
+    }
+
+    @Test
+    void 이메일_형식에_맞지_않으면_예외가_발생_한다() {
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kimsb7218", "daily1313!", "daily1313!", "김승범");
+
+        assertThatThrownBy(() -> authService.signUp(memberSignUpRequest))
+                .isInstanceOf(InvalidUsernameFormatException.class);
+    }
+
+    @Test
+    void 패스워드_값이_공백_이면_예외가_발생_한다() {
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kimsb7218@naver.com", "", "", "김승범");
+
+        assertThatThrownBy(() -> authService.signUp(memberSignUpRequest))
+                .isInstanceOf(InvalidPasswordFormatException.class);
+    }
+
+    @Test
+    void 패스워드_값이_형식에_맞지_않으면_예외가_발생_한다() {
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kimsb7218@naver.com", "daily1313", "daily1313", "김승범");
+
+        assertThatThrownBy(() -> authService.signUp(memberSignUpRequest))
+                .isInstanceOf(InvalidPasswordFormatException.class);
+    }
+
+    @Test
+    void 패스워드_값이_확인용_패스워드_값과_다르면_예외가_발생_한다() {
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kimsb7218@naver.com", "daily1313!", "daily1313", "김승범");
+
+        assertThatThrownBy(() -> authService.signUp(memberSignUpRequest))
+                .isInstanceOf(PasswordAndCheckedPasswordNotEqualsException.class);
+    }
+
+    @Test
+    void 이름이_공백_이면_예외가_발생_한다() {
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kimsb7218@naver.com", "daily1313!", "daily1313!", "");
+
+        assertThatThrownBy(() -> authService.signUp(memberSignUpRequest))
+                .isInstanceOf(InvalidNameFormatException.class);
+    }
+
+    @Test
+    void 이름이_두_글자_이상_네_글자_이하_가_아니면_예외가_발생_한다() {
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kimsb7218@naver.com", "daily1313!", "daily1313!", "김호랑나비");
+
+        assertThatThrownBy(() -> authService.signUp(memberSignUpRequest))
+                .isInstanceOf(InvalidNameFormatException.class);
+    }
+
+    @Test
+    void 회원가입_할때_이미_가입된_이메일_이면_예외가_발생_한다() {
+        Member member = Member.createMember("kimsb7218@naver.com", "daily1313!", "김승범");
+        given(memberRepository.existsByUsername(member.getUsername())).willReturn(true);
+
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kimsb7218@naver.com", "daily1313!", "daily1313!", "김승범");
+
+        assertThatThrownBy(() -> authService.signUp(memberSignUpRequest))
+                .isInstanceOf(UsernameAlreadyExistsException.class);
+    }
+
+    @Test
+    void 로그인_할때_비밀번호가_다르면_예외가_발생_한다() {
+        Member member = Member.createMember("kimsb7218@naver.com", "daily1313!", "김승범");
+        given(memberRepository.findByUsername(anyString())).willReturn(Optional.of(member));
+
+        MemberSignInRequest memberSignInRequest = new MemberSignInRequest("kimsb7218@naver.com","abcd1234!");
+
+        assertThatThrownBy(() -> authService.signIn(memberSignInRequest))
+                .isInstanceOf(PasswordNotEqualsException.class);
+    }
+
+    @Test
+    void 로그인_할때_가입된_이메일이_없으면_예외가_발생_한다() {
+        Member member = Member.createMember("kimsb7218@naver.com", "daily1313!", "김승범");
+        given(memberRepository.findByUsername(anyString())).willReturn(Optional.of(member));
+
+        MemberSignInRequest memberSignInRequest = new MemberSignInRequest("kimsb7219@naver.com","daily1313!");
+
+        assertThatThrownBy(() -> authService.signIn(memberSignInRequest))
+                .isInstanceOf(UsernameNotEqualsException.class);
+    }
+}

--- a/src/test/java/allercheck/backend/auth/presentation/AuthControllerUnitTest.java
+++ b/src/test/java/allercheck/backend/auth/presentation/AuthControllerUnitTest.java
@@ -1,0 +1,93 @@
+package allercheck.backend.auth.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import allercheck.backend.domain.auth.application.AuthService;
+import allercheck.backend.domain.auth.application.dto.MemberSignInRequest;
+import allercheck.backend.domain.auth.application.dto.MemberSignUpRequest;
+import allercheck.backend.domain.auth.presentation.AuthController;
+import allercheck.backend.domain.member.entity.Member;
+import allercheck.backend.global.jwt.TokenProvider;
+import allercheck.backend.global.web.interceptor.JwtInterceptor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(AuthController.class)
+class AuthControllerUnitTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @MockBean
+    private JwtInterceptor jwtInterceptor;
+
+    @Test
+    void 회원가입을_하면_멤버_응답_디티오를_반환한다() throws Exception {
+        //given
+        Member member = Member.createMember("kimsb7219@naver.com", "daily1313!","김승범");
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kimsb7219@naver.com", "daily1313!",
+                "daily1313!","김승범");
+        String content = objectMapper.writeValueAsString(memberSignUpRequest);
+        when(authService.signUp(any(MemberSignUpRequest.class))).thenReturn(member);
+
+        //when
+        ResultActions resultAction = mockMvc.perform(post("/api/auth/sign-up")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //then
+        resultAction
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.username").value("kimsb7219@naver.com"))
+                .andExpect(jsonPath("$.name").value("김승범"))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    void 로그인을_하면_엑세스_토큰을_반환한다() throws Exception {
+        //given
+        String accessToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjk4NDIyMDQwLCJleHAiOjE2OTg0NTgwNDB9.NYTXyO7DW8rl4WoZUDLUHARTleCl56vhlyc3Lm56XHw";
+        MemberSignInRequest memberSignInRequest = new MemberSignInRequest("kimsb7218@naver.com", "daily1313!");
+        String content = objectMapper.writeValueAsString(memberSignInRequest);
+        when(authService.signIn(any(MemberSignInRequest.class))).thenReturn(accessToken);
+
+        //when
+        ResultActions resultAction = mockMvc.perform(post("/api/auth/sign-in")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //then
+        resultAction
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value(accessToken))
+                .andDo(MockMvcResultHandlers.print());
+    }
+}

--- a/src/test/java/allercheck/backend/member/repository/MemberRepositoryUnitTest.java
+++ b/src/test/java/allercheck/backend/member/repository/MemberRepositoryUnitTest.java
@@ -1,0 +1,35 @@
+package allercheck.backend.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import allercheck.backend.domain.member.entity.Member;
+import allercheck.backend.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@DataJpaTest
+class MemberRepositoryUnitTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 회원을_등록한다() {
+        //given
+        Member member = Member.createMember("kimsb7218@naver.com", "daily1313!", "김승범");
+
+        //when
+        Member createdMember = memberRepository.save(member);
+
+        //then
+        assertThat(createdMember.getUsername()).isEqualTo(member.getUsername());
+    }
+}


### PR DESCRIPTION
1.  기존 Service Layer에서 회원가입에 대한 유효성 검증을 수행했는데, Domain에서 검증하도록 리팩토링
2.  AuthSerivce에서 ResponseDto(TokenResponse, MemberResponse)를 반환했지만, DDD(Domain-Driven Design) Layerd Architecture에 의하면 Application이 Presentation을 역참조하는 현상이 발생하여 Member 객체, String 객체가 반환되도록 리팩토링 
<p align="center"><img width="300"  alt="스크린샷 2023-10-30 오후 10 26 30" src="https://github.com/2023ICE/backend/assets/88074556/75ebd4bc-70be-42a4-a887-9e9ff82fa3ed"><p>

-  DDD Layered Architecture

  -   Prsentation Layer(Controller) : 클라이언트 요청에 응답하고 및 UI 제공하는 계층
  -   Application Layer(Service): 비즈니스 로직을 정의하는 (도메인 계층과 인프라 계층 연결) 계층
  -   Domain Layer(Entity): 비즈니스 규칙, 정보에 대한 도메인의 실질적인 정보를 가지고 책임지는 계층
  -   Infra Layer (Repository): 실질적으로 데이터 관리를 위한 RDB 연동 및 NoSQL 연동, 해당 계층에서 얻어온 데이터를 응용 계층 및 도메인 계층으로의 전달을 담당하는 계층

3. 비즈니스 로직을 담당하는 Serivce Layer 단위 테스트, Client의 요청 및 응답을 담당하는 Controller Layer 단위 테스트, RDB 연동을 담당하는 Repository 단위 테스트 추가 

확인하고 Merge한 후에 작업하시면 될 거 같아 진영아 ㅎㅎ
