### PR TITLE
[Feat/Member] 비밀번호 변경에 관한 검증 로직 추가

### DIFF
--- a/src/main/java/allercheck/backend/domain/member/application/MemberService.java
+++ b/src/main/java/allercheck/backend/domain/member/application/MemberService.java
@@ -1,0 +1,27 @@
+package allercheck.backend.domain.member.application;
+
+
+import allercheck.backend.domain.member.application.dto.MemberPasswordEditRequest;
+import allercheck.backend.domain.member.entity.Member;
+import allercheck.backend.domain.member.exception.MemberNotFoundException;
+import allercheck.backend.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public void changePassword(final Member member,
+                                 final MemberPasswordEditRequest memberPasswordEditRequest) {
+        Member currentMember = memberRepository.findByUsername(member.getUsername())
+                .orElseThrow(MemberNotFoundException::new);
+        currentMember.changePassword(memberPasswordEditRequest.getPresentPassword(),
+                memberPasswordEditRequest.getNewPassword(),
+                memberPasswordEditRequest.getCheckedNewPassword());
+    }
+}

--- a/src/main/java/allercheck/backend/domain/member/application/dto/MemberPasswordEditRequest.java
+++ b/src/main/java/allercheck/backend/domain/member/application/dto/MemberPasswordEditRequest.java
@@ -1,0 +1,21 @@
+package allercheck.backend.domain.member.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberPasswordEditRequest {
+
+    @NotBlank
+    private String presentPassword;
+
+    @NotBlank
+    private String newPassword;
+
+    @NotBlank
+    private String checkedNewPassword;
+}

--- a/src/main/java/allercheck/backend/domain/member/entity/Member.java
+++ b/src/main/java/allercheck/backend/domain/member/entity/Member.java
@@ -5,7 +5,9 @@ import allercheck.backend.domain.allergy.application.AllergyTypeSetConverter;
 import allercheck.backend.domain.auth.exception.InvalidNameFormatException;
 import allercheck.backend.domain.auth.exception.InvalidPasswordFormatException;
 import allercheck.backend.domain.auth.exception.InvalidUsernameFormatException;
+import allercheck.backend.domain.auth.exception.NewPasswordNotEqualsException;
 import allercheck.backend.domain.auth.exception.PasswordNotEqualsException;
+import allercheck.backend.domain.auth.exception.PresentPasswordNotEqualsException;
 import allercheck.backend.domain.auth.exception.UsernameNotEqualsException;
 import allercheck.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -95,5 +97,24 @@ public class Member extends BaseEntity {
 
     public void changeAllergies(EnumSet<AllergyType> allergies) {
         this.allergies = allergies;
+    }
+
+    public void changePassword(final String presentPassword, final String newPassword, final String checkedNewPassword) {
+        validatePassword(presentPassword, newPassword, checkedNewPassword);
+        this.password = newPassword;
+    }
+
+    private void validatePassword(final String presentPassword, final String newPassword, final String checkedNewPassword) {
+        if(!this.password.equals(presentPassword)) {
+            throw new PresentPasswordNotEqualsException();
+        }
+
+        if(!newPassword.equals(checkedNewPassword)) {
+            throw new NewPasswordNotEqualsException();
+        }
+
+        if(password == null || !password.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$")) {
+            throw new InvalidPasswordFormatException();
+        }
     }
 }

--- a/src/main/java/allercheck/backend/domain/member/presentation/MemberController.java
+++ b/src/main/java/allercheck/backend/domain/member/presentation/MemberController.java
@@ -1,0 +1,31 @@
+package allercheck.backend.domain.member.presentation;
+
+import allercheck.backend.domain.member.application.MemberService;
+import allercheck.backend.domain.member.application.dto.MemberPasswordEditRequest;
+import allercheck.backend.domain.member.entity.Member;
+import allercheck.backend.global.web.resolver.annotation.AuthMember;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PatchMapping("/change-password")
+    public ResponseEntity<Void> changePassword(@AuthMember final Member member,
+                                                 @Valid @RequestBody final MemberPasswordEditRequest memberPasswordEditRequest) {
+        memberService.changePassword(member, memberPasswordEditRequest);
+        return ResponseEntity.status(HttpStatus.OK)
+                .build();
+    }
+}

--- a/src/main/java/allercheck/backend/domain/member/presentation/MemberController.java
+++ b/src/main/java/allercheck/backend/domain/member/presentation/MemberController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
-@RequestMapping("/api/members")
+@RequestMapping("/api/member")
 @RequiredArgsConstructor
 @RestController
 public class MemberController {


### PR DESCRIPTION
- 비밀번호 변경에 관한 로직 Member Entity에서 처리하도록 설계
- Response Type : Void

To do 
- 서버 배포 시, Intellij IDEA -> Setting -> File Encoding에서 설정해준 UTF-8을 어떻게 처리해줄지 고려
- OpenAPI 관련 예외처리
- Member Change API 및 OpenAPI 관련 Junit5 Test code작성 