### PR TITLE
[Fix] #6 Exception of openapi

### DIFF
--- a/src/main/java/allercheck/backend/domain/allergy/entity/AllergyProperties.java
+++ b/src/main/java/allercheck/backend/domain/allergy/entity/AllergyProperties.java
@@ -1,17 +1,14 @@
 package allercheck.backend.domain.allergy.entity;
 
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 import java.util.Map;
 
 
-@Getter
-@PropertySource(value = "classpath:allergy.properties", encoding = "UTF-8")
 @Component
-@Slf4j
+@PropertySource(value = "classpath:allergy.properties", encoding = "UTF-8")
 public class AllergyProperties {
 
     private final Map<String, AllergyType> allergenicIngredients;

--- a/src/main/java/allercheck/backend/domain/allergy/presentation/AllergyController.java
+++ b/src/main/java/allercheck/backend/domain/allergy/presentation/AllergyController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/allergy")
-@Controller
+@RestController
 public class AllergyController {
 
     private final AllergyService allergyService;

--- a/src/main/java/allercheck/backend/domain/openapi/exception/NoMatchingRecipeException.java
+++ b/src/main/java/allercheck/backend/domain/openapi/exception/NoMatchingRecipeException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.openapi.exception;
+
+public class NoMatchingRecipeException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/domain/openapi/exception/NoMoreRecipeException.java
+++ b/src/main/java/allercheck/backend/domain/openapi/exception/NoMoreRecipeException.java
@@ -1,0 +1,4 @@
+package allercheck.backend.domain.openapi.exception;
+
+public class NoMoreRecipeException extends RuntimeException {
+}

--- a/src/main/java/allercheck/backend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/allercheck/backend/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package allercheck.backend.global.error;
 
 import allercheck.backend.domain.auth.exception.*;
 import allercheck.backend.domain.member.exception.MemberNotFoundException;
+import allercheck.backend.domain.openapi.exception.NoMatchingRecipeException;
+import allercheck.backend.domain.openapi.exception.NoMoreRecipeException;
 import allercheck.backend.domain.openapi.exception.OpenApiConnectionFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -93,5 +95,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> openApiConnectionFailureException() {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body("opan api 연결에 실패했습니다.");
+    }
+
+    @ExceptionHandler(NoMoreRecipeException.class)
+    public ResponseEntity<?> noMoreRecipeException() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("레시피를 가져올 수 있는 페이지를 넘었습니다.");
+    }
+
+    @ExceptionHandler(NoMatchingRecipeException.class)
+    public ResponseEntity<?> noMatchingRecipeException() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("검색어에 해당하는 레시피를 찾을 수 없습니다.");
     }
 }


### PR DESCRIPTION
## Summary
- openapi 예외를 추가해줬습니다.
- 한 페이지에 레시피가 5개씩 나올 수 있게 로직을 수정했습니다.

## Describe
마지막 페이지인 상태에서 다음 페이지를 요청할 때, 쿼리 파라미터로 넘어온 레시피 이름과 매칭되는 레시피가 없을 때 이 두가지 경우를 클라이언트 예외로 처리해줬습니다.
서버 예외의 경우는 openapi 서버 상 문제, allercheck 서버 상 문제 두 가지 경우가 있습니다.
특히 openapi 서버 상 문제가 꽤 다양한데 다음과 같습니다.
<img width="993" alt="스크린샷 2023-11-29 오후 7 12 23" src="https://github.com/2023ICE/backend/assets/90890216/be289e77-3970-4a1a-8fec-243a7a672c2b">
위와 같이 다양한 문제를 클라이언트가 세세하게 알 필요는 없을 것입니다.
따라서 openapi 서버 상 문제, allercheck 서버 상 문제를 모두 500 internal server error 로 묶어서 한가지 예외로 클라이언트에게 알려주고, 디테일한 처리는 서버 로그로 해결해야겠다는 판단을 했습니다.

## To do
- 디테일한 예외 로그 처리
- 라이트세일에 nginx 적용 후 바로 github action 으로 배포 자동화

## Etc
- 요런 풀리퀘스트 양식을 적용해봤습니다.